### PR TITLE
Added default values for plugin-name & plugin-version header.

### DIFF
--- a/src/Vipps.net.sln
+++ b/src/Vipps.net.sln
@@ -20,8 +20,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vipps.net.Codegen", "Vipps.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vipps.net.IntegrationTests", "Tests\Vipps.net.IntegrationTests\Vipps.net.IntegrationTests.csproj", "{42DD89A8-0AE4-4CCD-9CAC-39B8F217805D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vipps.net.ConsoleDemo", "Vipps.net.ConsoleDemo\Vipps.net.ConsoleDemo.csproj", "{FCC8ABDD-5527-4387-9A78-F3C779919889}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,10 +50,6 @@ Global
 		{42DD89A8-0AE4-4CCD-9CAC-39B8F217805D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{42DD89A8-0AE4-4CCD-9CAC-39B8F217805D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{42DD89A8-0AE4-4CCD-9CAC-39B8F217805D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FCC8ABDD-5527-4387-9A78-F3C779919889}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FCC8ABDD-5527-4387-9A78-F3C779919889}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FCC8ABDD-5527-4387-9A78-F3C779919889}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FCC8ABDD-5527-4387-9A78-F3C779919889}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Vipps.net.sln
+++ b/src/Vipps.net.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vipps.net.Codegen", "Vipps.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vipps.net.IntegrationTests", "Tests\Vipps.net.IntegrationTests\Vipps.net.IntegrationTests.csproj", "{42DD89A8-0AE4-4CCD-9CAC-39B8F217805D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vipps.net.ConsoleDemo", "Vipps.net.ConsoleDemo\Vipps.net.ConsoleDemo.csproj", "{FCC8ABDD-5527-4387-9A78-F3C779919889}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{42DD89A8-0AE4-4CCD-9CAC-39B8F217805D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{42DD89A8-0AE4-4CCD-9CAC-39B8F217805D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{42DD89A8-0AE4-4CCD-9CAC-39B8F217805D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCC8ABDD-5527-4387-9A78-F3C779919889}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCC8ABDD-5527-4387-9A78-F3C779919889}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCC8ABDD-5527-4387-9A78-F3C779919889}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCC8ABDD-5527-4387-9A78-F3C779919889}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Vipps.net/Infrastructure/VippsHttpClient.cs
+++ b/src/Vipps.net/Infrastructure/VippsHttpClient.cs
@@ -82,8 +82,8 @@ namespace Vipps.net.Infrastructure
                 { "Vipps-System-Name", assemblyName.Name },
                 { "Vipps-System-Version", assemblyVersion },
                 { "Merchant-Serial-Number", _options.MerchantSerialNumber },
-                { "Vipps-System-Plugin-Name", _options.PluginName },
-                { "Vipps-System-Plugin-Version", _options.PluginVersion }
+                { "Vipps-System-Plugin-Name", string.IsNullOrWhiteSpace(_options.PluginName) ? "acme-plugin" : _options.PluginName },
+                { "Vipps-System-Plugin-Version", string.IsNullOrWhiteSpace(_options.PluginVersion) ? "0.0.1" : _options.PluginVersion }
             };
         }
     }

--- a/src/Vipps.net/Infrastructure/VippsHttpClient.cs
+++ b/src/Vipps.net/Infrastructure/VippsHttpClient.cs
@@ -84,11 +84,15 @@ namespace Vipps.net.Infrastructure
                 { "Merchant-Serial-Number", _options.MerchantSerialNumber },
                 {
                     "Vipps-System-Plugin-Name",
-                    string.IsNullOrWhiteSpace(_options.PluginName) ? "acme-plugin" : _options.PluginName
+                    string.IsNullOrWhiteSpace(_options.PluginName)
+                        ? "acme-plugin"
+                        : _options.PluginName
                 },
                 {
                     "Vipps-System-Plugin-Version",
-                    string.IsNullOrWhiteSpace(_options.PluginVersion) ? "0.0.1" : _options.PluginVersion
+                    string.IsNullOrWhiteSpace(_options.PluginVersion)
+                        ? "0.0.1"
+                        : _options.PluginVersion
                 }
             };
         }

--- a/src/Vipps.net/Infrastructure/VippsHttpClient.cs
+++ b/src/Vipps.net/Infrastructure/VippsHttpClient.cs
@@ -82,8 +82,14 @@ namespace Vipps.net.Infrastructure
                 { "Vipps-System-Name", assemblyName.Name },
                 { "Vipps-System-Version", assemblyVersion },
                 { "Merchant-Serial-Number", _options.MerchantSerialNumber },
-                { "Vipps-System-Plugin-Name", string.IsNullOrWhiteSpace(_options.PluginName) ? "acme-plugin" : _options.PluginName },
-                { "Vipps-System-Plugin-Version", string.IsNullOrWhiteSpace(_options.PluginVersion) ? "0.0.1" : _options.PluginVersion }
+                {
+                    "Vipps-System-Plugin-Name",
+                    string.IsNullOrWhiteSpace(_options.PluginName) ? "acme-plugin" : _options.PluginName
+                },
+                {
+                    "Vipps-System-Plugin-Version",
+                    string.IsNullOrWhiteSpace(_options.PluginVersion) ? "0.0.1" : _options.PluginVersion
+                }
             };
         }
     }

--- a/src/Vipps.net/Vipps.net.csproj
+++ b/src/Vipps.net/Vipps.net.csproj
@@ -6,7 +6,7 @@
     <Product>Vipps.net</Product>
     <Description>Vipps.net SDK</Description>
     <PackageId>Vipps.net</PackageId>
-    <Version>0.9.5</Version>
+    <Version>0.9.6</Version>
     <Authors>Vipps Mobilepay AS</Authors>
     <Company>Vipps Mobilepay AS</Company>
     <Title>Vipps SDK .Net</Title>


### PR DESCRIPTION
Plugin-Name: "acme-plugin"
Plugin-Version: 0.0.1

With no user defined plugin-name or plugin-version header defined in call:
<img width="315" alt="image" src="https://github.com/vippsas/dotnet-sdk/assets/2693698/e14a99bc-60c7-4e02-8941-f3c84c5946d8">

With user-defined header:
<img width="315" alt="image" src="https://github.com/vippsas/dotnet-sdk/assets/2693698/04d3ebb2-0355-43e4-89d5-488ec360700a">
